### PR TITLE
Infra: CI 파이프라인 구성, 코드 커버리지 적용

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -47,4 +47,4 @@ jobs:
           token: ${{ github.token }}
           min-coverage-overall: 80
           min-coverage-changed-files: 80
-          pass-emoji: ✅
+          pass-emoji: ':white_check_mark:'

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,0 +1,50 @@
+name: CI Pipeline
+
+on:
+  pull_request:
+    branches: [ main, dev ]
+  push:
+    branches: [ dev ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      # Gradle 라이브러리 캐싱
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build --no-daemon
+
+      # PR comment에 JaCoCo 리포트 남기기
+      - name: Leave a comment for test coverage
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: 📊 Test Coverage Report
+          paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ github.token }}
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80
+          pass-emoji: ✅

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ jacocoTestReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
-                            "seungki/cicdpractice/api/domain/**",
+                            "uranus/taskmanager/api/domain/**",
                             "**/*Application*",
                             "**/*Request*",
                             "**/*Response*",

--- a/build.gradle
+++ b/build.gradle
@@ -1,42 +1,93 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.3'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.3'
+    id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'com.uranus'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
-dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testCompileOnly 'org.projectlombok:lombok:1.18.34'
-	testAnnotationProcessor 'org.projectlombok:lombok:1.18.34'
+jacoco {
+    toolVersion = "0.8.10"
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
+jacocoTestReport {
+    reports {
+        xml.required = true
+        html.required = true
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            "seungki/cicdpractice/api/domain/**",
+                            "**/*Application*",
+                            "**/*Request*",
+                            "**/*Response*",
+                            "**/*Exception*"
+                    ])
+                })
+        )
+        finalizedBy(jacocoTestCoverageVerification)
+    }
+
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule {
+                enabled = true
+                element = 'CLASS'
+
+                limit {
+                    counter = 'LINE'
+                    value = 'COVEREDRATIO'
+                    minimum = 0.80
+                }
+
+                excludes = [
+                        "uranus.taskmanager.api.domain.**",
+                        "**.*Application*",
+                        "**.*Request*",
+                        "**.*Response*",
+                        "**.*Exception*"
+                ]
+            }
+        }
+    }
+
+    dependencies {
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
+        compileOnly 'org.projectlombok:lombok'
+        runtimeOnly 'com.h2database:h2'
+        annotationProcessor 'org.projectlombok:lombok'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testCompileOnly 'org.projectlombok:lombok:1.18.34'
+        testAnnotationProcessor 'org.projectlombok:lombok:1.18.34'
+    }
+
+    tasks.named('test') {
+        useJUnitPlatform()
+        finalizedBy jacocoTestReport
+    }
 }


### PR DESCRIPTION
## 🚀 설명
- GitHub Actions를 사용한 CI 파이프라인 구성
- 코드 커버리지 적용
- 커버리지 최소 기준 `LINE`으로 80% 적용

---
## ✅ 변경 사항
- [x] GitHub Actions 워크플로우 추가
- [x] JaCoCo 플러그인 추가
- [x] JaCoCo 관련 설정 추가
- [x] PR 댓글에 자동 JaCoCo 리포트([madrapps/jacoco-report@v1.2](https://github.com/Madrapps/jacoco-report) 사용)

---
## 🚩 관련 이슈, PR
- #3 

---
## 📖 참고
- [https://github.com/seungki1011/CICD-using-Github-Actions](https://github.com/seungki1011/CICD-using-Github-Actions)