### PR TITLE
`Workspace` 도메인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,4 +109,9 @@ jacocoTestReport {
         useJUnitPlatform()
         finalizedBy jacocoTestReport
     }
+
+    tasks.named('jacocoTestReport') {
+        dependsOn 'test'
+        dependsOn 'compileJava'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ jacocoTestReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
-                            "uranus/taskmanager/api/domain/**",
+                            "com.uranus/taskmanager/api/domain/**",
                             "**/*Application*",
                             "**/*Request*",
                             "**/*Response*",
@@ -81,7 +81,7 @@ jacocoTestReport {
                 }
 
                 excludes = [
-                        "uranus.taskmanager.api.domain.**",
+                        "com.uranus.taskmanager.api.domain.**",
                         "**.*Application*",
                         "**.*Request*",
                         "**.*Response*",

--- a/src/main/java/com/uranus/taskmanager/api/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/WorkspaceController.java
@@ -20,19 +20,19 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/workspaces")
 public class WorkspaceController {
 
 	private final WorkspaceService workspaceService;
 
-	@PostMapping("/workspaces")
+	@PostMapping
 	public ResponseEntity<WorkspaceResponse> createWorkspace(@RequestBody @Valid WorkspaceCreateRequest request) {
 		WorkspaceResponse response = workspaceService.create(request);
 		log.info("[WorkspaceController.createWorkspace] response = {}", response);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
-	@GetMapping("/workspaces/{workspaceId}")
+	@GetMapping("/{workspaceId}")
 	public ResponseEntity<WorkspaceResponse> getWorkspace(@PathVariable String workspaceId) {
 		WorkspaceResponse response = workspaceService.get(workspaceId);
 		log.info("[WorkspaceController.getWorkspace] response = {}", response);

--- a/src/main/java/com/uranus/taskmanager/api/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/WorkspaceController.java
@@ -2,6 +2,8 @@ package com.uranus.taskmanager.api.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,9 +29,14 @@ public class WorkspaceController {
 	public ResponseEntity<WorkspaceResponse> createWorkspace(@RequestBody @Valid WorkspaceCreateRequest request) {
 		WorkspaceResponse response = workspaceService.create(request);
 		log.info("[WorkspaceController.createWorkspace] response = {}", response);
-		return ResponseEntity
-			.status(HttpStatus.CREATED)
-			.body(response);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@GetMapping("/workspaces/{workspaceId}")
+	public ResponseEntity<WorkspaceResponse> getWorkspace(@PathVariable String workspaceId) {
+		WorkspaceResponse response = workspaceService.get(workspaceId);
+		log.info("[WorkspaceController.getWorkspace] response = {}", response);
+		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
 }

--- a/src/main/java/com/uranus/taskmanager/api/domain/workspace/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/domain/workspace/Workspace.java
@@ -32,4 +32,9 @@ public class Workspace {
 		this.name = name;
 		this.description = description;
 	}
+
+	public void setWorkspaceId(String workspaceId) {
+		this.workspaceId = workspaceId;
+	}
+
 }

--- a/src/main/java/com/uranus/taskmanager/api/domain/workspace/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/domain/workspace/Workspace.java
@@ -1,7 +1,5 @@
 package com.uranus.taskmanager.api.domain.workspace;
 
-import java.util.UUID;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -22,14 +20,15 @@ public class Workspace {
 	private Long id;
 
 	@Column(unique = true)
-	private String workspaceCode = UUID.randomUUID().toString();
+	private String workspaceId;
 
 	private String name;
 	private String description;
 
 	@Builder
-	public Workspace(Long id, String name, String description) {
+	public Workspace(Long id, String workspaceId, String name, String description) {
 		this.id = id;
+		this.workspaceId = workspaceId;
 		this.name = name;
 		this.description = description;
 	}

--- a/src/main/java/com/uranus/taskmanager/api/repository/WorkspaceRepository.java
+++ b/src/main/java/com/uranus/taskmanager/api/repository/WorkspaceRepository.java
@@ -1,8 +1,12 @@
 package com.uranus.taskmanager.api.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.uranus.taskmanager.api.domain.workspace.Workspace;
 
 public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
+
+	Optional<Workspace> findByWorkspaceId(String workspaceId);
 }

--- a/src/main/java/com/uranus/taskmanager/api/response/WorkspaceResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/response/WorkspaceResponse.java
@@ -11,19 +11,20 @@ import lombok.ToString;
 public class WorkspaceResponse {
 
 	private final Long id;
+	private final String workspaceId;
 	private final String name;
 	private final String description;
-	private final String workspaceCode;
+
 	//    private final LocalDateTime createdAt;
 	//    private final LocalDateTime updatedAt;
 	//    private final LocalDateTime viewedAt;
 
 	@Builder
-	public WorkspaceResponse(Long id, String name, String description, String workspaceCode) {
+	public WorkspaceResponse(Long id, String workspaceId, String name, String description) {
 		this.id = id;
+		this.workspaceId = workspaceId;
 		this.name = name;
 		this.description = description;
-		this.workspaceCode = workspaceCode;
 	}
 
 	public static WorkspaceResponse fromEntity(Workspace workspace) {
@@ -31,7 +32,7 @@ public class WorkspaceResponse {
 			.id(workspace.getId())
 			.name(workspace.getName())
 			.description(workspace.getDescription())
-			.workspaceCode(workspace.getWorkspaceCode())
+			.workspaceId(workspace.getWorkspaceId())
 			.build();
 	}
 

--- a/src/main/java/com/uranus/taskmanager/api/service/WorkspaceService.java
+++ b/src/main/java/com/uranus/taskmanager/api/service/WorkspaceService.java
@@ -1,5 +1,7 @@
 package com.uranus.taskmanager.api.service;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,8 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class WorkspaceService {
 
 	private final WorkspaceRepository workspaceRepository;
@@ -21,7 +23,16 @@ public class WorkspaceService {
 	@Transactional
 	public WorkspaceResponse create(WorkspaceCreateRequest request) {
 		Workspace workspace = workspaceRepository.save(request.toEntity());
+		workspace.setWorkspaceId(UUID.randomUUID().toString());
 		log.info("[WorkspaceService.create] workspace = {}", workspace);
+		return WorkspaceResponse.fromEntity(workspace);
+	}
+
+	@Transactional(readOnly = true)
+	public WorkspaceResponse get(String workspaceId) {
+		Workspace workspace = workspaceRepository.findByWorkspaceId(workspaceId)
+			// RuntimeException -> WorkspaceNotFoundException 정의 예정
+			.orElseThrow(() -> new RuntimeException("Workspace was not found!"));
 		return WorkspaceResponse.fromEntity(workspace);
 	}
 

--- a/src/test/java/com/uranus/taskmanager/api/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/service/WorkspaceServiceTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,8 +29,8 @@ class WorkspaceServiceTest {
 	private WorkspaceRepository workspaceRepository;
 
 	@Test
-	@DisplayName("Workspace를 생성하면 응답의 id는 1이어야 하고, 레포지토리는 한번 호출되어야 한다")
-	public void test1() {
+	@DisplayName("워크스페이스 생성 요청 시 새로운 워크스페이스가 생성되고 workspaceId가 설정된 후, WorkspaceResponse를 반환한다")
+	void test1() {
 		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
 			.name("Test Workspace")
 			.description("Test Description")
@@ -45,6 +48,42 @@ class WorkspaceServiceTest {
 		assertThat(response.getId()).isEqualTo(1L);
 		verify(workspaceRepository, times(1)).save(any(Workspace.class));
 
+	}
+
+	@Test
+	@DisplayName("유효한 workspaceId로 워크스페이스를 조회하면, 워크스페이스를 반환한다.")
+	void test2() {
+		String workspaceId = UUID.randomUUID().toString();
+		Workspace mockWorkspace = Workspace.builder()
+			.id(1L)
+			.workspaceId(workspaceId)
+			.name("Test Workspace")
+			.description("Test Description")
+			.build();
+
+		when(workspaceRepository.findByWorkspaceId(workspaceId))
+			.thenReturn(Optional.of(mockWorkspace));
+
+		WorkspaceResponse response = workspaceService.get(workspaceId);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getId()).isEqualTo(1L);
+		assertThat(response.getWorkspaceId()).isEqualTo(workspaceId);
+		verify(workspaceRepository, times(1)).findByWorkspaceId(workspaceId);
+	}
+
+	@Test
+	@DisplayName("유효하지 workspaceId로 워크스페이스를 조회하면, WorkspaceNotFoundException 발생")
+	void test3() {
+		String invalidWorkspaceId = UUID.randomUUID().toString();
+
+		when(workspaceRepository.findByWorkspaceId(invalidWorkspaceId))
+			.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> workspaceService.get(invalidWorkspaceId))
+			.isInstanceOf(RuntimeException.class); // RuntimeException -> WorkspaceNotFoundException 변경 예정
+
+		verify(workspaceRepository, times(1)).findByWorkspaceId(invalidWorkspaceId);
 	}
 
 }

--- a/src/test/java/com/uranus/taskmanager/integrationtest/WorkspaceIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/integrationtest/WorkspaceIntegrationTest.java
@@ -38,7 +38,7 @@ class WorkspaceIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("POST /workspaces: 응답의 필드가 제공한 값과 일치하고, workspaceCode는 존재해야한다.")
+	@DisplayName("POST: 응답의 필드가 제공한 값과 일치하고, workspaceCode는 존재해야한다.")
 	public void test1() throws Exception {
 
 		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
@@ -54,12 +54,12 @@ class WorkspaceIntegrationTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.name").value("Test Workspace"))
 			.andExpect(jsonPath("$.description").value("Test Description"))
-			.andExpect(jsonPath("$.workspaceCode").exists())
+			.andExpect(jsonPath("$.workspaceId").exists())
 			.andDo(print());
 	}
 
 	@Test
-	@DisplayName("POST /workspaces: DB에 하나의 값만 저장된다.")
+	@DisplayName("POST: DB에 하나의 값만 저장된다.")
 	public void test2() throws Exception {
 
 		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()


### PR DESCRIPTION
## 🚀 설명
- `Workspace` 도메인과 관련된 개발 진행
- `workspaceId`의 값을 생성하는 로직을 서비스 계층으로 이동
- 코드 커버리지 관련 설정 수정

---
## ✅ 변경 사항
- [x] `workspaceId`를 이용한 워크스페이스 단건 조회 구현
- [x] 단건 조회에 대한 테스트 코드 추가
- [x] 테스트 네임 수정
- [x] `workspaceId` 생성 로직을 서비스 계층으로 리팩토링
- [x] 코드 커버리지 제외 항목 수정

---
## 🚩 관련 이슈, PR

---
## 📖 참고

---
## ⏳ 할 예정
- `WorkspaceNotFoundException` 구현
- 예외 처리
- `Workspace` 도메인의 나머지 부분은 `User` 도메인 부터 완성하고 진행할 예정(인증, 인가 관련 설정이 필요함)