### PR TITLE
Feat/#15 authorization v1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,8 @@ jacocoTestReport {
                         "**.*Application*",
                         "**.*Request*",
                         "**.*Response*",
-                        "**.*Exception*"
+                        "**.*Exception*",
+                        "**.*Key*"
                 ]
             }
         }

--- a/src/main/java/com/uranus/taskmanager/api/auth/AuthInterceptor.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/AuthInterceptor.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import com.uranus.taskmanager.api.exception.UserNotLoggedInException;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -14,13 +16,11 @@ public class AuthInterceptor implements HandlerInterceptor {
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 		if (handler instanceof HandlerMethod method) {
-
-			// @LoginRequired 애노테이션이 있는지 확인
 			LoginRequired loginRequired = method.getMethodAnnotation(LoginRequired.class);
 			if (loginRequired != null) {
-				HttpSession session = request.getSession(false); // 세션에서 로그인 정보 확인
+				HttpSession session = request.getSession(false);
 				if (session == null || session.getAttribute(SessionKey.LOGIN_MEMBER) == null) {
-					throw new RuntimeException("Unauthorized"); // Todo: UnauthorizedException 만들기
+					throw new UserNotLoggedInException();
 				}
 			}
 		}

--- a/src/main/java/com/uranus/taskmanager/api/auth/AuthInterceptor.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/AuthInterceptor.java
@@ -1,0 +1,29 @@
+package com.uranus.taskmanager.api.auth;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		if (handler instanceof HandlerMethod method) {
+
+			// @LoginRequired 애노테이션이 있는지 확인
+			LoginRequired loginRequired = method.getMethodAnnotation(LoginRequired.class);
+			if (loginRequired != null) {
+				HttpSession session = request.getSession(false); // 세션에서 로그인 정보 확인
+				if (session == null || session.getAttribute(SessionKey.LOGIN_MEMBER) == null) {
+					throw new RuntimeException("Unauthorized"); // Todo: UnauthorizedException 만들기
+				}
+			}
+		}
+		return true;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/auth/LoginRequired.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/LoginRequired.java
@@ -1,0 +1,11 @@
+package com.uranus.taskmanager.api.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginRequired {
+}

--- a/src/main/java/com/uranus/taskmanager/api/auth/SessionKey.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/SessionKey.java
@@ -1,0 +1,5 @@
+package com.uranus.taskmanager.api.auth;
+
+public abstract class SessionKey {
+	public static final String LOGIN_MEMBER = "loginMember";
+}

--- a/src/main/java/com/uranus/taskmanager/api/auth/SessionKey.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/SessionKey.java
@@ -1,5 +1,5 @@
 package com.uranus.taskmanager.api.auth;
 
 public abstract class SessionKey {
-	public static final String LOGIN_MEMBER = "loginMember";
+	public static final String LOGIN_MEMBER = "loginId";
 }

--- a/src/main/java/com/uranus/taskmanager/api/config/WebMvcConfig.java
+++ b/src/main/java/com/uranus/taskmanager/api/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.uranus.taskmanager.api.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.uranus.taskmanager.api.auth.AuthInterceptor;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+	private final AuthInterceptor authInterceptor;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(authInterceptor); // 패턴은 추가하지 않음. 애노테이션 기반으로 인가할 예정.
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
@@ -10,9 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.uranus.taskmanager.api.auth.LoginRequired;
 import com.uranus.taskmanager.api.auth.SessionKey;
 import com.uranus.taskmanager.api.request.LoginRequest;
-import com.uranus.taskmanager.api.request.SignupRequest;
 import com.uranus.taskmanager.api.response.LoginResponse;
-import com.uranus.taskmanager.api.response.SignupResponse;
 import com.uranus.taskmanager.api.service.AuthService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,24 +24,12 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 	/**
 	 * Todo
-	 * (세션 or Token 불필요)
 	 * 로그인 - 로그인하면 세션을 생성. 해당 세션ID를 클라에게 전달.
 	 *          서버는 이후 클라가 보낸 쿠키를 사용해 세션ID 식별
-	 * 회원 가입 - 새로운 멤버 등록
-	 */
-	/**
-	 * Todo 2
 	 * 로그아웃 - 세션 끝내기
-	 * 회원 가입을 MemberController로 이동
 	 */
 	private final AuthService authService;
-
-	@PostMapping("/signup")
-	public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest signupRequest) {
-		SignupResponse signupResponse = authService.signup(signupRequest);
-		return ResponseEntity.status(HttpStatus.OK).body(signupResponse);
-	}
-
+	
 	@PostMapping("/login")
 	public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest,
 		HttpServletRequest request) {

--- a/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
@@ -42,11 +42,8 @@ public class AuthController {
 		 * loginId가 null은 아니지만 DB에 없고 email을 통해 조회한 경우, 또는 그 반대의 케이스.
 		 */
 		HttpSession session = request.getSession();
-		if (loginRequest.getLoginId() != null) {
-			session.setAttribute(SessionKey.LOGIN_MEMBER, loginResponse.getLoginId());
-		} else {
-			session.setAttribute(SessionKey.LOGIN_MEMBER, loginResponse.getEmail());
-		}
+
+		session.setAttribute(SessionKey.LOGIN_MEMBER, loginResponse.getLoginId());
 
 		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
 	}

--- a/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
 	 * 로그아웃 - 세션 끝내기
 	 */
 	private final AuthService authService;
-	
+
 	@PostMapping("/login")
 	public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest,
 		HttpServletRequest request) {
@@ -53,12 +53,12 @@ public class AuthController {
 
 	@LoginRequired
 	@PostMapping("/logout")
-	public ResponseEntity<String> logout(HttpServletRequest request) {
+	public ResponseEntity<Void> logout(HttpServletRequest request) {
 		HttpSession session = request.getSession(false);
 		if (session != null) {
 			session.invalidate();
 		}
-		return ResponseEntity.ok("Logout Successful"); // Todo: 추후에 ApiResponse 클래스 만들고 리팩토링
+		return ResponseEntity.noContent().build(); // Todo: 추후에 ApiResponse 클래스 만들고 리팩토링
 	}
 
 }

--- a/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
@@ -7,15 +7,21 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.uranus.taskmanager.api.auth.LoginRequired;
+import com.uranus.taskmanager.api.auth.SessionKey;
+import com.uranus.taskmanager.api.request.LoginRequest;
 import com.uranus.taskmanager.api.request.SignupRequest;
+import com.uranus.taskmanager.api.response.LoginResponse;
 import com.uranus.taskmanager.api.response.SignupResponse;
 import com.uranus.taskmanager.api.service.AuthService;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1/auth") // Resource를 members가 아닌 auth로 표현하는 것이 좋을까?
 @RequiredArgsConstructor
 public class AuthController {
 	/**
@@ -25,7 +31,11 @@ public class AuthController {
 	 *          서버는 이후 클라가 보낸 쿠키를 사용해 세션ID 식별
 	 * 회원 가입 - 새로운 멤버 등록
 	 */
-
+	/**
+	 * Todo 2
+	 * 로그아웃 - 세션 끝내기
+	 * 회원 가입을 MemberController로 이동
+	 */
 	private final AuthService authService;
 
 	@PostMapping("/signup")
@@ -33,4 +43,36 @@ public class AuthController {
 		SignupResponse signupResponse = authService.signup(signupRequest);
 		return ResponseEntity.status(HttpStatus.OK).body(signupResponse);
 	}
+
+	@PostMapping("/login")
+	public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest,
+		HttpServletRequest request) {
+		LoginResponse loginResponse = authService.login(loginRequest);
+
+		/**
+		 * 세션에 loginId 또는 email을 세션에 저장한다
+		 * Todo:
+		 * 아래의 케이스에 대한 처리가 필요하다.
+		 * loginId가 null은 아니지만 DB에 없고 email을 통해 조회한 경우, 또는 그 반대의 케이스.
+		 */
+		HttpSession session = request.getSession();
+		if (loginRequest.getLoginId() != null) {
+			session.setAttribute(SessionKey.LOGIN_MEMBER, loginResponse.getLoginId());
+		} else {
+			session.setAttribute(SessionKey.LOGIN_MEMBER, loginResponse.getEmail());
+		}
+
+		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
+	}
+
+	@LoginRequired
+	@PostMapping("/logout")
+	public ResponseEntity<String> logout(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session != null) {
+			session.invalidate();
+		}
+		return ResponseEntity.ok("Logout Successful"); // Todo: 추후에 ApiResponse 클래스 만들고 리팩토링
+	}
+
 }

--- a/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.uranus.taskmanager.api.exception.AuthenticationExcpetion;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -21,10 +23,11 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ProblemDetail> unexpectedException(Exception exception) {
 
-		log.error("Unexpected Exception occurred: {}", exception.getMessage());
+		log.error("Unexpected Exception: {}", exception.getMessage(), exception);
 
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
 		problemDetail.setTitle("Unexpected Exception");
+		problemDetail.setDetail("An unexpected problem has occurred");
 
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
@@ -34,10 +37,11 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(RuntimeException.class)
 	public ResponseEntity<ProblemDetail> unexpectedRuntimeException(RuntimeException exception) {
 
-		log.error("Unexpected RuntimeException occurred: {}", exception.getMessage());
+		log.error("Unexpected RuntimeException {}", exception.getMessage(), exception);
 
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
 		problemDetail.setTitle("Unexpected RuntimeException");
+		problemDetail.setDetail("An unexpected problem has occurred");
 
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
@@ -47,7 +51,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ProblemDetail> handleValidationException(MethodArgumentNotValidException exception) {
 
-		log.error("Request Validation Failed: {}", exception.getMessage());
+		log.error("Field Validation Failed: {}", exception.getMessage(), exception);
 
 		BindingResult bindingResult = exception.getBindingResult();
 		Map<String, String> fieldErrors = new HashMap<>();
@@ -66,4 +70,17 @@ public class GlobalExceptionHandler {
 			.body(problemDetail);
 	}
 
+	@ExceptionHandler(AuthenticationExcpetion.class)
+	public ResponseEntity<ProblemDetail> handleAuthenticationException(AuthenticationExcpetion exception) {
+
+		log.error("Authentication Related Exception: {}", exception.getMessage(), exception);
+
+		ProblemDetail problemDetail = ProblemDetail.forStatus(exception.getHttpStatus());
+		problemDetail.setTitle(exception.getTitle());
+		problemDetail.setDetail(exception.getMessage());
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(problemDetail);
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.uranus.taskmanager.api.exception.AuthenticationExcpetion;
+import com.uranus.taskmanager.api.exception.AuthenticationException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -70,8 +70,8 @@ public class GlobalExceptionHandler {
 			.body(problemDetail);
 	}
 
-	@ExceptionHandler(AuthenticationExcpetion.class)
-	public ResponseEntity<ProblemDetail> handleAuthenticationException(AuthenticationExcpetion exception) {
+	@ExceptionHandler(AuthenticationException.class)
+	public ResponseEntity<ProblemDetail> handleAuthenticationException(AuthenticationException exception) {
 
 		log.error("Authentication Related Exception: ", exception);
 

--- a/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
@@ -80,7 +80,7 @@ public class GlobalExceptionHandler {
 		problemDetail.setDetail(exception.getMessage());
 
 		return ResponseEntity
-			.status(HttpStatus.BAD_REQUEST)
+			.status(exception.getHttpStatus())
 			.body(problemDetail);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
@@ -1,12 +1,12 @@
 package com.uranus.taskmanager.api.controller;
 
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -24,7 +24,7 @@ public class GlobalExceptionHandler {
 		log.error("Unexpected Exception occurred: {}", exception.getMessage());
 
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
-		problemDetail.setTitle("Unexpected Exception occurred");
+		problemDetail.setTitle("Unexpected Exception");
 
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
@@ -37,7 +37,7 @@ public class GlobalExceptionHandler {
 		log.error("Unexpected RuntimeException occurred: {}", exception.getMessage());
 
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
-		problemDetail.setTitle("Unexpected RuntimeException occurred");
+		problemDetail.setTitle("Unexpected RuntimeException");
 
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
@@ -47,20 +47,19 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ProblemDetail> handleValidationException(MethodArgumentNotValidException exception) {
 
-		log.error("Validation Failure occurred: {}", exception.getMessage());
+		log.error("Request Validation Failed: {}", exception.getMessage());
+
+		BindingResult bindingResult = exception.getBindingResult();
+		Map<String, String> fieldErrors = new HashMap<>();
+
+		for (FieldError fieldError : bindingResult.getFieldErrors()) {
+			fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
+		}
 
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
-		problemDetail.setTitle("Validation failed");
-		problemDetail.setDetail("One or more fields have validation errors.");
-
-		// 필드 이름을 키로 하고 검증 메시지 리스트를 값으로 하는 맵 생성
-		Map<String, List<String>> validationErrors = exception.getBindingResult().getFieldErrors().stream()
-			.collect(Collectors.groupingBy(
-				FieldError::getField,       // 필드 이름을 키로 사용
-				Collectors.mapping(FieldError::getDefaultMessage, Collectors.toList()) // 검증 메시지를 리스트로 수집
-			));
-
-		problemDetail.setProperty("validation", validationErrors);
+		problemDetail.setTitle("Field Validation Error");
+		problemDetail.setDetail("One or more fields have validation errors");
+		problemDetail.setProperty("fieldErrors", fieldErrors);
 
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ProblemDetail> unexpectedException(Exception exception) {
 
-		log.error("Unexpected Exception: {}", exception.getMessage(), exception);
+		log.error("Unexpected Exception: ", exception);
 
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
 		problemDetail.setTitle("Unexpected Exception");
@@ -37,7 +37,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(RuntimeException.class)
 	public ResponseEntity<ProblemDetail> unexpectedRuntimeException(RuntimeException exception) {
 
-		log.error("Unexpected RuntimeException {}", exception.getMessage(), exception);
+		log.error("Unexpected RuntimeException :", exception);
 
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
 		problemDetail.setTitle("Unexpected RuntimeException");
@@ -51,7 +51,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ProblemDetail> handleValidationException(MethodArgumentNotValidException exception) {
 
-		log.error("Field Validation Failed: {}", exception.getMessage(), exception);
+		log.error("Field Validation Failed: ", exception);
 
 		BindingResult bindingResult = exception.getBindingResult();
 		Map<String, String> fieldErrors = new HashMap<>();
@@ -73,7 +73,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(AuthenticationExcpetion.class)
 	public ResponseEntity<ProblemDetail> handleAuthenticationException(AuthenticationExcpetion exception) {
 
-		log.error("Authentication Related Exception: {}", exception.getMessage(), exception);
+		log.error("Authentication Related Exception: ", exception);
 
 		ProblemDetail problemDetail = ProblemDetail.forStatus(exception.getHttpStatus());
 		problemDetail.setTitle(exception.getTitle());

--- a/src/main/java/com/uranus/taskmanager/api/controller/MemberController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/MemberController.java
@@ -1,8 +1,17 @@
 package com.uranus.taskmanager.api.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.uranus.taskmanager.api.request.SignupRequest;
+import com.uranus.taskmanager.api.response.SignupResponse;
+import com.uranus.taskmanager.api.service.MemberService;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -11,12 +20,19 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 	/**
 	 * Todo
-	 * (세션 or Token이 필요)
-	 * 로그아웃 - 로그인한 사용자의 세션 무효화 및 쿠키 삭제
+	 * 회원 가입 - 새로운 멤버 등록
 	 * 회원 정보 조회/수정
 	 * 비밀번호 찾기 - 가입한 이메일 통한 비밀번호 찾기 (세션 불필요)
 	 * 비밀번호 변경
 	 * 회원 탈퇴
 	 * 침여하고 있는 워크스페이스 목록 조회
 	 */
+	private final MemberService memberService;
+
+	@PostMapping("/signup")
+	public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest signupRequest) {
+		SignupResponse signupResponse = memberService.signup(signupRequest);
+		return ResponseEntity.status(HttpStatus.OK).body(signupResponse);
+	}
+
 }

--- a/src/main/java/com/uranus/taskmanager/api/exception/AuthenticationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/AuthenticationException.java
@@ -5,19 +5,19 @@ import org.springframework.http.HttpStatus;
 import lombok.Getter;
 
 @Getter
-public abstract class AuthenticationExcpetion extends RuntimeException {
+public abstract class AuthenticationException extends RuntimeException {
 
 	private final String title;
 	private final String message;
 	private final HttpStatus httpStatus;
 
-	public AuthenticationExcpetion(String title, String message, HttpStatus httpStatus) {
+	public AuthenticationException(String title, String message, HttpStatus httpStatus) {
 		this.title = title;
 		this.message = message;
 		this.httpStatus = httpStatus;
 	}
 
-	public AuthenticationExcpetion(String message, String title,
+	public AuthenticationException(String message, String title,
 		HttpStatus httpStatus, Throwable cause) {
 		super(cause);
 		this.title = title;

--- a/src/main/java/com/uranus/taskmanager/api/exception/AuthenticationExcpetion.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/AuthenticationExcpetion.java
@@ -1,0 +1,27 @@
+package com.uranus.taskmanager.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public abstract class AuthenticationExcpetion extends RuntimeException {
+
+	private final String title;
+	private final String message;
+	private final HttpStatus httpStatus;
+
+	public AuthenticationExcpetion(String title, String message, HttpStatus httpStatus) {
+		this.title = title;
+		this.message = message;
+		this.httpStatus = httpStatus;
+	}
+
+	public AuthenticationExcpetion(String message, String title,
+		HttpStatus httpStatus, Throwable cause) {
+		super(cause);
+		this.title = title;
+		this.message = message;
+		this.httpStatus = httpStatus;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginIdentityException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginIdentityException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class InvalidLoginIdentityException extends AuthenticationExcpetion {
+public class InvalidLoginIdentityException extends AuthenticationException {
 
 	private static final String TITLE = "Invalid Login ID or Email";
 	private static final String MESSAGE = "Please provide a valid login ID or Email.";

--- a/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginIdentityException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginIdentityException.java
@@ -1,0 +1,18 @@
+package com.uranus.taskmanager.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidLoginIdentityException extends AuthenticationExcpetion {
+
+	private static final String TITLE = "Invalid Login ID or Email";
+	private static final String MESSAGE = "Please provide a valid login ID or Email.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
+	public InvalidLoginIdentityException() {
+		super(TITLE, MESSAGE, HTTP_STATUS);
+	}
+
+	public InvalidLoginIdentityException(Throwable cause) {
+		super(TITLE, MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginPasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginPasswordException.java
@@ -1,0 +1,17 @@
+package com.uranus.taskmanager.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidLoginPasswordException extends AuthenticationExcpetion {
+	private static final String TITLE = "Invalid Login Password";
+	private static final String MESSAGE = "Please provide a valid login pasword.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
+	public InvalidLoginPasswordException() {
+		super(TITLE, MESSAGE, HTTP_STATUS);
+	}
+
+	public InvalidLoginPasswordException(Throwable cause) {
+		super(TITLE, MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginPasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginPasswordException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class InvalidLoginPasswordException extends AuthenticationExcpetion {
+public class InvalidLoginPasswordException extends AuthenticationException {
 	private static final String TITLE = "Invalid Login Password";
 	private static final String MESSAGE = "Please provide a valid login pasword.";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;

--- a/src/main/java/com/uranus/taskmanager/api/exception/UserNotLoggedInException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/UserNotLoggedInException.java
@@ -1,0 +1,17 @@
+package com.uranus.taskmanager.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserNotLoggedInException extends AuthenticationExcpetion {
+	private static final String TITLE = "Login Required";
+	private static final String MESSAGE = "Login is required to access.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
+	public UserNotLoggedInException() {
+		super(TITLE, MESSAGE, HTTP_STATUS);
+	}
+
+	public UserNotLoggedInException(Throwable cause) {
+		super(TITLE, MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/exception/UserNotLoggedInException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/UserNotLoggedInException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class UserNotLoggedInException extends AuthenticationExcpetion {
+public class UserNotLoggedInException extends AuthenticationException {
 	private static final String TITLE = "Login Required";
 	private static final String MESSAGE = "Login is required to access.";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;

--- a/src/main/java/com/uranus/taskmanager/api/repository/MemberRepository.java
+++ b/src/main/java/com/uranus/taskmanager/api/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByLoginId(String username);
 
 	Optional<Member> findByEmail(String email);
+
+	Optional<Member> findByLoginIdOrEmail(String email, String loginId);
 }

--- a/src/main/java/com/uranus/taskmanager/api/request/LoginRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/request/LoginRequest.java
@@ -2,7 +2,6 @@ package com.uranus.taskmanager.api.request;
 
 import com.uranus.taskmanager.api.domain.member.Member;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +10,6 @@ import lombok.Getter;
 @Builder
 public class LoginRequest {
 
-	@NotBlank(message = "Email must not be blank")
-	@Email(message = "Email should be valid")
 	private String email;
 
 	private String loginId;

--- a/src/main/java/com/uranus/taskmanager/api/request/SignupRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/request/SignupRequest.java
@@ -5,6 +5,7 @@ import com.uranus.taskmanager.api.domain.member.Member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,7 +20,8 @@ public class SignupRequest {
 	private final String loginId;
 
 	@NotBlank(message = "Email must not be blank")
-	@Email(message = "Email should be valid")
+	@Size(min = 5, max = 254, message = "Email must be between 5 and 254 characters")
+	@Email(message = "Email should be in a valid format")
 	private final String email;
 
 	@NotBlank(message = "Password must not be blank")

--- a/src/main/java/com/uranus/taskmanager/api/service/AuthService.java
+++ b/src/main/java/com/uranus/taskmanager/api/service/AuthService.java
@@ -6,9 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.uranus.taskmanager.api.domain.member.Member;
 import com.uranus.taskmanager.api.repository.MemberRepository;
 import com.uranus.taskmanager.api.request.LoginRequest;
-import com.uranus.taskmanager.api.request.SignupRequest;
 import com.uranus.taskmanager.api.response.LoginResponse;
-import com.uranus.taskmanager.api.response.SignupResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,14 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthService {
 
 	private final MemberRepository memberRepository;
-
-	@Transactional
-	public SignupResponse signup(SignupRequest signupRequest) {
-		Member member = signupRequest.toEntity();
-		// Todo: password 암호화
-		return SignupResponse.fromEntity(memberRepository.save(member));
-	}
-
+	
 	@Transactional
 	public LoginResponse login(LoginRequest loginRequest) {
 		/**

--- a/src/main/java/com/uranus/taskmanager/api/service/AuthService.java
+++ b/src/main/java/com/uranus/taskmanager/api/service/AuthService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.domain.member.Member;
+import com.uranus.taskmanager.api.exception.InvalidLoginIdentityException;
+import com.uranus.taskmanager.api.exception.InvalidLoginPasswordException;
 import com.uranus.taskmanager.api.repository.MemberRepository;
 import com.uranus.taskmanager.api.request.LoginRequest;
 import com.uranus.taskmanager.api.response.LoginResponse;
@@ -15,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthService {
 
 	private final MemberRepository memberRepository;
-	
+
 	@Transactional
 	public LoginResponse login(LoginRequest loginRequest) {
 		/**
@@ -24,10 +26,11 @@ public class AuthService {
 		 * password 암호화 로직 후에 검증 로직 수정
 		 */
 		Member member = memberRepository.findByLoginIdOrEmail(loginRequest.getLoginId(), loginRequest.getEmail())
-			.stream()
-			.filter(m -> m.getPassword().equals(loginRequest.getPassword()))
-			.findFirst()
-			.orElseThrow(() -> new RuntimeException("Invalid login credentials or password"));
+			.orElseThrow(InvalidLoginIdentityException::new);
+
+		if (!member.getPassword().equals(loginRequest.getPassword())) {
+			throw new InvalidLoginPasswordException();
+		}
 
 		return LoginResponse.fromEntity(member);
 	}

--- a/src/main/java/com/uranus/taskmanager/api/service/AuthService.java
+++ b/src/main/java/com/uranus/taskmanager/api/service/AuthService.java
@@ -5,7 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.domain.member.Member;
 import com.uranus.taskmanager.api.repository.MemberRepository;
+import com.uranus.taskmanager.api.request.LoginRequest;
 import com.uranus.taskmanager.api.request.SignupRequest;
+import com.uranus.taskmanager.api.response.LoginResponse;
 import com.uranus.taskmanager.api.response.SignupResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -21,5 +23,21 @@ public class AuthService {
 		Member member = signupRequest.toEntity();
 		// Todo: password 암호화
 		return SignupResponse.fromEntity(memberRepository.save(member));
+	}
+
+	@Transactional
+	public LoginResponse login(LoginRequest loginRequest) {
+		/**
+		 * Todo
+		 * loginId, email 조회와 password 검증 분리
+		 * password 암호화 로직 후에 검증 로직 수정
+		 */
+		Member member = memberRepository.findByLoginIdOrEmail(loginRequest.getLoginId(), loginRequest.getEmail())
+			.stream()
+			.filter(m -> m.getPassword().equals(loginRequest.getPassword()))
+			.findFirst()
+			.orElseThrow(() -> new RuntimeException("Invalid login credentials or password"));
+
+		return LoginResponse.fromEntity(member);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/service/MemberService.java
+++ b/src/main/java/com/uranus/taskmanager/api/service/MemberService.java
@@ -1,0 +1,25 @@
+package com.uranus.taskmanager.api.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.uranus.taskmanager.api.domain.member.Member;
+import com.uranus.taskmanager.api.repository.MemberRepository;
+import com.uranus.taskmanager.api.request.SignupRequest;
+import com.uranus.taskmanager.api.response.SignupResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public SignupResponse signup(SignupRequest signupRequest) {
+		Member member = signupRequest.toEntity();
+		// Todo: password 암호화
+		return SignupResponse.fromEntity(memberRepository.save(member));
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/api/controller/AuthControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/AuthControllerTest.java
@@ -1,0 +1,114 @@
+package com.uranus.taskmanager.api.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uranus.taskmanager.api.auth.SessionKey;
+import com.uranus.taskmanager.api.exception.UserNotLoggedInException;
+import com.uranus.taskmanager.api.request.LoginRequest;
+import com.uranus.taskmanager.api.response.LoginResponse;
+import com.uranus.taskmanager.api.service.AuthService;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+	@MockBean
+	private AuthService authService;
+
+	@Test
+	@DisplayName("로그인에 성공하면 200 OK를 기대하고, 세션에 로그인ID가 저장된다")
+	void test1() throws Exception {
+		// given
+		MockHttpSession session = new MockHttpSession();
+		LoginRequest loginRequest = LoginRequest.builder()
+			.loginId("user123")
+			.email("test@gmail.com")
+			.password("password123!")
+			.build();
+		LoginResponse loginResponse = LoginResponse.builder()
+			.loginId("user123")
+			.email("test@gmail.com")
+			.build();
+		when(authService.login(any(LoginRequest.class))).thenReturn(loginResponse);
+
+		// when & then
+		mockMvc.perform((post("/api/v1/auth/login")
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(loginRequest))))
+			.andExpect(jsonPath("$.loginId").value("user123"))
+			.andExpect(jsonPath("$.email").value("test@gmail.com"))
+			.andExpect(status().isOk())
+			.andDo(print());
+
+		assertThat(session.getAttribute(SessionKey.LOGIN_MEMBER)).isEqualTo("user123");
+	}
+
+	@Test
+	@DisplayName("로그인 시 비밀번호 필드의 빈 검증이 실패하면 400 BAD_REQUEST를 기대한다")
+	void test2() throws Exception {
+		// given
+		LoginRequest loginRequest = LoginRequest.builder()
+			.loginId("user123")
+			.password("")
+			.build();
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(loginRequest)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.fieldErrors.password").value("Password must not be blank"))
+			.andDo(print());
+
+	}
+
+	@Test
+	@DisplayName("로그아웃 시 세션이 무효화된다")
+	void test3() throws Exception {
+		// given
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(SessionKey.LOGIN_MEMBER, "user123");
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/logout")
+				.session(session))
+			.andExpect(status().isNoContent())
+			.andDo(print());
+
+		assertThat(session.isInvalid()).isTrue();
+
+	}
+
+	@Test
+	@DisplayName("로그인 하지 않은 상태에서 로그아웃 시도 시 UserNotLoggedInException 발생")
+	void test4() throws Exception {
+		// given
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/logout"))
+			.andExpect(status().isUnauthorized())
+			.andExpect(result -> assertThat(result.getResolvedException()).isInstanceOf(UserNotLoggedInException.class))
+			.andDo(print());
+
+	}
+
+}

--- a/src/test/java/com/uranus/taskmanager/api/controller/MemberControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/MemberControllerTest.java
@@ -22,20 +22,20 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uranus.taskmanager.api.request.SignupRequest;
-import com.uranus.taskmanager.api.service.AuthService;
+import com.uranus.taskmanager.api.service.MemberService;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@WebMvcTest(AuthController.class)
-class AuthControllerTest {
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Autowired
 	private ObjectMapper objectMapper;
 	@MockBean
-	private AuthService authService;
+	private MemberService memberService;
 
 	@Test
 	@DisplayName("회원 가입에 검증을 통과하면 OK를 기대한다")
@@ -47,7 +47,7 @@ class AuthControllerTest {
 			.build();
 		String requestBody = objectMapper.writeValueAsString(signupRequest);
 
-		mockMvc.perform(post("/api/v1/auth/signup")
+		mockMvc.perform(post("/api/v1/members/signup")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isOk())
@@ -71,7 +71,7 @@ class AuthControllerTest {
 			.build();
 		String requestBody = objectMapper.writeValueAsString(signupRequest);
 
-		mockMvc.perform(post("/api/v1/auth/signup")
+		mockMvc.perform(post("/api/v1/members/signup")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
@@ -99,7 +99,7 @@ class AuthControllerTest {
 			.build();
 		String requestBody = objectMapper.writeValueAsString(signupRequest);
 
-		mockMvc.perform(post("/api/v1/auth/signup")
+		mockMvc.perform(post("/api/v1/members/signup")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
@@ -133,7 +133,7 @@ class AuthControllerTest {
 		String requestBody = objectMapper.writeValueAsString(signupRequest);
 
 		// when & then
-		mockMvc.perform(post("/api/v1/auth/signup")
+		mockMvc.perform(post("/api/v1/members/signup")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())

--- a/src/test/java/com/uranus/taskmanager/api/controller/MemberControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/MemberControllerTest.java
@@ -1,6 +1,5 @@
 package com.uranus.taskmanager.api.controller;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -75,7 +74,7 @@ class MemberControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.validation.loginId").value(loginIdValidMsg))
+			.andExpect(jsonPath("$.fieldErrors.loginId").value(loginIdValidMsg))
 			.andDo(print());
 	}
 
@@ -103,27 +102,23 @@ class MemberControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.validation.password")
+			.andExpect(jsonPath("$.fieldErrors.password")
 				.value(passwordValidMsg))
 			.andDo(print());
 	}
 
 	static Stream<Arguments> provideInvalidInputs() {
-		String loginIdValidMsg = "User ID must not be blank";
-		String emailValidMsg = "Email must not be blank";
-		String passwordValidMsg = "Password must not be blank";
 		return Stream.of(
-			arguments(null, null, null, loginIdValidMsg, emailValidMsg, passwordValidMsg), // null
-			arguments("", "", "", loginIdValidMsg, emailValidMsg, passwordValidMsg),   // 빈 문자열
-			arguments(" ", " ", " ", loginIdValidMsg, emailValidMsg, passwordValidMsg)  // 공백
+			arguments(null, null, null), // null
+			arguments("", "", ""),   // 빈 문자열
+			arguments(" ", " ", " ")  // 공백
 		);
 	}
 
 	@ParameterizedTest
 	@MethodSource("provideInvalidInputs")
 	@DisplayName("회원 가입에 loginId, email, password는 null, 공백, 빈 문자이면 안된다")
-	void test4(String loginId, String email, String password,
-		String loginIdValidMsg, String emailValidMsg, String passwordValidMsg) throws Exception {
+	void test4(String loginId, String email, String password) throws Exception {
 		// given
 		SignupRequest signupRequest = SignupRequest.builder()
 			.loginId(loginId)
@@ -137,9 +132,9 @@ class MemberControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.validation.loginId").value(hasItem(loginIdValidMsg)))
-			.andExpect(jsonPath("$.validation.email").value(hasItem(emailValidMsg)))
-			.andExpect(jsonPath("$.validation.password").value(hasItem(passwordValidMsg)))
+			.andExpect(jsonPath("$.fieldErrors.loginId").exists())
+			.andExpect(jsonPath("$.fieldErrors.email").exists())
+			.andExpect(jsonPath("$.fieldErrors.password").exists())
 			.andDo(print());
 	}
 

--- a/src/test/java/com/uranus/taskmanager/api/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/WorkspaceControllerTest.java
@@ -1,6 +1,5 @@
 package com.uranus.taskmanager.api.controller;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -58,6 +57,13 @@ class WorkspaceControllerTest {
 			.andDo(print());
 	}
 
+	/**
+	 * Todo
+	 * 필드 검증에 대한 단위 테스트 작성법 찾아보기
+	 * Q1: 같은 필드에 대해서 동일한 항목에 대해 검증 애노테이션이 겹치는 경우 어떻게 검증?
+	 * - 예시: @NotBlank와 @Size(min = 2, max = 50)을 적용한 필드에 " "(공백)가 들어가는 경우
+	 * Q2: 검증 메세지 자체를 검증하는 것은 과연 효율적인가? 애노테이션 종류를 검증하는 것이 더 좋을지도?
+	 */
 	static Stream<Arguments> provideInvalidInputs() {
 		String nameValidMsg = "Workspace name must not be blank";
 		String descriptionValidMsg = "Workspace description must not be blank";
@@ -83,8 +89,10 @@ class WorkspaceControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.validation.name").value(hasItem(nameValidMsg)))
-			.andExpect(jsonPath("$.validation.description").value(hasItem(descriptionValidMsg)))
+			.andExpect(jsonPath("$.title").value("Invalid input"))
+			.andExpect(jsonPath("$.detail").value("One or more fields have fieldErrors errors."))
+			.andExpect(jsonPath("$.fieldErrors.name").exists())
+			.andExpect(jsonPath("$.fieldErrors.description").exists())
 			.andDo(print());
 	}
 
@@ -114,8 +122,8 @@ class WorkspaceControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.validation.name").value(hasItem(nameValidMsg)))
-			.andExpect(jsonPath("$.validation.description").value(hasItem(descriptionValidMsg)))
+			.andExpect(jsonPath("$.fieldErrors.name").value(nameValidMsg))
+			.andExpect(jsonPath("$.fieldErrors.description").value(descriptionValidMsg))
 			.andDo(print());
 	}
 

--- a/src/test/java/com/uranus/taskmanager/api/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/WorkspaceControllerTest.java
@@ -65,19 +65,17 @@ class WorkspaceControllerTest {
 	 * Q2: 검증 메세지 자체를 검증하는 것은 과연 효율적인가? 애노테이션 종류를 검증하는 것이 더 좋을지도?
 	 */
 	static Stream<Arguments> provideInvalidInputs() {
-		String nameValidMsg = "Workspace name must not be blank";
-		String descriptionValidMsg = "Workspace description must not be blank";
 		return Stream.of(
-			arguments(null, null, nameValidMsg, descriptionValidMsg), // null
-			arguments("", "", nameValidMsg, descriptionValidMsg),   // 빈 문자열
-			arguments(" ", " ", nameValidMsg, descriptionValidMsg)  // 공백
+			arguments(null, null), // null
+			arguments("", ""),   // 빈 문자열
+			arguments(" ", " ")  // 공백
 		);
 	}
 
 	@ParameterizedTest
 	@MethodSource("provideInvalidInputs")
 	@DisplayName("워크스페이스 생성: name과 description은 null, 빈 문자열, 공백이면 안된다")
-	public void test2(String name, String description, String nameValidMsg, String descriptionValidMsg) throws
+	public void test2(String name, String description) throws
 		Exception {
 		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
 			.name(name)
@@ -89,8 +87,8 @@ class WorkspaceControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.title").value("Invalid input"))
-			.andExpect(jsonPath("$.detail").value("One or more fields have fieldErrors errors."))
+			.andExpect(jsonPath("$.title").value("Field Validation Error"))
+			.andExpect(jsonPath("$.detail").value("One or more fields have validation errors"))
 			.andExpect(jsonPath("$.fieldErrors.name").exists())
 			.andExpect(jsonPath("$.fieldErrors.description").exists())
 			.andDo(print());

--- a/src/test/java/com/uranus/taskmanager/api/service/MemberServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/service/MemberServiceTest.java
@@ -12,10 +12,10 @@ import com.uranus.taskmanager.api.request.SignupRequest;
 import com.uranus.taskmanager.api.response.SignupResponse;
 
 @SpringBootTest
-class AuthServiceTest {
+class MemberServiceTest {
 
 	@Autowired
-	private AuthService authService;
+	private MemberService memberService;
 	@Autowired
 	private MemberRepository memberRepository;
 
@@ -30,7 +30,7 @@ class AuthServiceTest {
 			.build();
 
 		// when
-		SignupResponse signupResponse = authService.signup(signupRequest);
+		SignupResponse signupResponse = memberService.signup(signupRequest);
 
 		// then
 		assertThat(signupResponse.getLoginId()).isEqualTo("testuser");


### PR DESCRIPTION
## 🚀 설명
- 로그인, 로그아웃에 대한 기능 구현
- 추후에 회원 가입 시 패스워드 암호화 로직을 추가하게 되면, 전체적인 리팩토링 필요
- Authentication 관련 커스텀 예외 추가
- `GlobalExceptionHandler`의 로직 일부 수정
- `ErrorResponse` 클래스를 만들지, `ProblemDetail`을 사용할지 고려 중
- 인터페이스에 의존하도록 설계하는 것을 고려 중.(추후 JWT 도입도 고려)
- 회원 가입을 `MemberController`, `MemberService`로 이동

---
## ✅ 변경 사항
- [x] 로그인 기능 추가
- [x] `AuthInterceptor`와 `@LoginRequired`를 사용해서 로그인이 필요한 API 위에 적용
- [x] 세션 쿠키 사용
- [x] 로그아웃 기능 추가
- [x] `RuntimeException`을 상속받는 `AuthenticationException`을 만들어서 해당 예외를 상속받는 하위 예외 구현

---
## 🚩 관련 이슈, PR
- #15 

---
## 📖 참고
